### PR TITLE
Fix compiler warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ num-traits = ""
 [dev-dependencies]
 rand = ""
 image = "0.22.4"
+rustfix = ""

--- a/src/gfx3d/pipeline.rs
+++ b/src/gfx3d/pipeline.rs
@@ -73,6 +73,7 @@ impl Pipeline {
     }
 
     pub fn render(&mut self, pge: &mut PGE, triangles: &Vec<Triangle>, tex: &Sprite) { // flags: RenderOptions, cull_dir: CullDirection) {
+        #[allow(unused_variables)]
         let mut tri_count = 0;
         let world_view = self.world * self.view;
 

--- a/src/gfx3d/pipeline.rs
+++ b/src/gfx3d/pipeline.rs
@@ -1,8 +1,8 @@
 use crate::color::Color;
-use crate::WHITE;
+
 use crate::gfx3d::plane::Plane;
 use crate::gfx3d::vec4d::Vec4d;
-use crate::{PGE, Pixel};
+use crate::{PGE};
 use crate::gfx3d::triangle::Triangle;
 use crate::Sprite;
 use super::vec3d::Vec3d;

--- a/src/gfx3d/pipeline.rs
+++ b/src/gfx3d/pipeline.rs
@@ -235,7 +235,7 @@ impl Pipeline {
 		let mut dv1 = v2 - v1;
 		let mut du1 = u2 - u1;
         let mut dw1 = w2 - w1;
-        let mut dc1 = c2 - c1;
+        let mut _dc1 = c2 - c1;
 
 		let dy2 = y3 - y1;
 		let dx2 = x3 - x1;
@@ -247,10 +247,10 @@ impl Pipeline {
         let mut tex_u: f32;
         let mut tex_v: f32; 
         let mut tex_w: f32;
-        let mut col_r: f32;
-        let mut col_g: f32;
-        let mut col_b: f32;
-        let mut col_a: f32;
+        let mut _col_r: f32;
+        let mut _col_g: f32;
+        let mut _col_b: f32;
+        let mut _col_a: f32;
 
 		let mut dax_step = 0.0; 
         let mut du1_step = 0.0; 
@@ -274,10 +274,10 @@ impl Pipeline {
 		    du1_step = du1 / dy1.abs() as f32;
 		    dv1_step = dv1 / dy1.abs() as f32;
             dw1_step = dw1 / dy1.abs() as f32;
-            dc1r_step = dc1.r / dy1.abs() as f32;
-            dc1g_step = dc1.g / dy1.abs() as f32;
-            dc1b_step = dc1.b / dy1.abs() as f32;
-            dc1a_step = dc1.a / dy1.abs() as f32;
+            dc1r_step = _dc1.r / dy1.abs() as f32;
+            dc1g_step = _dc1.g / dy1.abs() as f32;
+            dc1b_step = _dc1.b / dy1.abs() as f32;
+            dc1a_step = _dc1.a / dy1.abs() as f32;
         }
 
 		if dy2 > 0 {
@@ -330,10 +330,10 @@ impl Pipeline {
 					tex_u = (1.0 - t) * tex_su + t * tex_eu;
 					tex_v = (1.0 - t) * tex_sv + t * tex_ev;
 					tex_w = (1.0 - t) * tex_sw + t * tex_ew;
-					col_r = (1.0 - t) * col_sr + t * col_er;
-					col_g = (1.0 - t) * col_sg + t * col_eg;
-					col_b = (1.0 - t) * col_sb + t * col_eb;
-                    col_a = (1.0 - t) * col_sa + t * col_ea;
+					_col_r = (1.0 - t) * col_sr + t * col_er;
+					_col_g = (1.0 - t) * col_sg + t * col_eg;
+					_col_b = (1.0 - t) * col_sb + t * col_eb;
+                    _col_a = (1.0 - t) * col_sa + t * col_ea;
                     // TODO - use interpolated color!!!!
 					if tex_w > self.depth_buffer[(i * pge.screen_width + j) as usize] {
 						pge.draw(j, i, &tex.sample(tex_u / tex_w, tex_v / tex_w));
@@ -350,7 +350,7 @@ impl Pipeline {
 		dv1 = v3 - v2;
 		du1 = u3 - u2;
 		dw1 = w3 - w2;
-		dc1 = c3 - c2;
+		_dc1 = c3 - c2;
 
 		if dy1 > 0 { dax_step = dx1 as f32 / dy1.abs() as f32; }
 		if dy2 > 0 { dbx_step = dx2 as f32 / dy2.abs() as f32; }
@@ -402,10 +402,10 @@ impl Pipeline {
 					tex_u = (1.0 - t) * tex_su + t * tex_eu;
 					tex_v = (1.0 - t) * tex_sv + t * tex_ev;
                     tex_w = (1.0 - t) * tex_sw + t * tex_ew;
-                    col_r = (1.0 - t) * col_sr + t * col_er;
-					col_g = (1.0 - t) * col_sg + t * col_eg;
-					col_b = (1.0 - t) * col_sb + t * col_eb;
-                    col_a = (1.0 - t) * col_sa + t * col_ea;
+                    _col_r = (1.0 - t) * col_sr + t * col_er;
+					_col_g = (1.0 - t) * col_sg + t * col_eg;
+					_col_b = (1.0 - t) * col_sb + t * col_eb;
+                    _col_a = (1.0 - t) * col_sa + t * col_ea;
                     // TODO - use interpolated color!!!!
 
                     if tex_w > self.depth_buffer[(i * pge.screen_width + j) as usize] {

--- a/src/gfx3d/plane.rs
+++ b/src/gfx3d/plane.rs
@@ -1,4 +1,4 @@
-use super::vec3d::Vec3d;
+
 use super::vec4d::Vec4d;
 
 #[derive(Debug, Clone, Copy)]

--- a/src/gfx3d/triangle.rs
+++ b/src/gfx3d/triangle.rs
@@ -1,5 +1,5 @@
-use crate::Sprite;
-use crate::PGE;
+
+
 use crate::{Pixel};
 use super::vec3d::Vec3d;
 use super::vec4d::Vec4d;


### PR DESCRIPTION
Firstly, I'd like to say that I'm a huge fan of this project and would love to see this published on `crates.io`. I've been working on building a gameboy emulator and have been using this library for the frontend, and it works great!

In order to make this library a bit easier to work with, this PR gets rid of the compiler warnings, either by fixing them where possible, or silencing them. The changes are (each in a separate commit):
 - Remove unused imports (done automatically using [rustfix](https://github.com/rust-lang/rustfix))
 - Change camel case variable names to snake case
 - Silence unused variable warnings using `#allow(unused_variables)`
 - Silence unread variable warnings by renaming them (`foo` -> `_foo`), as I didn't want to get rid of them