### PR TITLE
Remove key repeat delay

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ impl PGE {
 
         if let Some(win) = &mut self.window {
             win.limit_update_rate(None);
-	    win.set_key_repeat_delay(0.0);
+            win.set_key_repeat_delay(0.0);
             //win.limit_update_rate(Some(std::time::Duration::from_millis(2)));
         }
         if !state.on_user_create() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,7 @@ impl PGE {
 
         if let Some(win) = &mut self.window {
             win.limit_update_rate(None);
+	    win.set_key_repeat_delay(0.0);
             //win.limit_update_rate(Some(std::time::Duration::from_millis(2)));
         }
         if !state.on_user_create() {


### PR DESCRIPTION
### Smooth out input

I noticed this issue while working with winit on another project. By default, Windows has a delay between initial keypress and repeating the key. While winit does not currently have the ability to remove this delay, minifb does. By default the repeat delay is 0.25 seconds.

By setting the delay to zero, anyone making keyboard input using this library that requires holding down a key should notice smoother input.

Since this does mean polling hardware events significantly more often in a loop, some performance considerations may need to be taken into account, but something significantly shorter than 0.25 seconds should probably be used.